### PR TITLE
Add departure time selection to course sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@
 
 |||
 | --- | --- |
-|経路探索|[サンプルを確認](http://z0lw.github.io/GUI/sample/sample.html)|
+|経路探索（時刻指定）|[サンプルを確認](http://z0lw.github.io/GUI/sample/sample.html)|
 |鉄道駅の時刻表|[サンプルを確認](http://z0lw.github.io/GUI/sample/stationTimeTable.html)|
 |区間の時刻表|[サンプルを確認](http://z0lw.github.io/GUI/sample/sectionTimeTable.html)|
 |鉄道駅時刻表の列車情報|[サンプルを確認](http://z0lw.github.io/GUI/sample/trainTimeTable.html)|

--- a/sample/sample.html
+++ b/sample/sample.html
@@ -37,7 +37,8 @@ function init(){
   // 日付入力パーツ初期化
   dateTimeApp = new expGuiDateTime(document.getElementById("dateTime"));
   dateTimeApp.setConfigure("ssl", true);
-  dateTimeApp.dispDateTime(dateTimeApp.SEARCHTYPE_PLAIN);
+  // ダイヤ探索に設定し時間選択を可能にする
+  dateTimeApp.dispDateTime(dateTimeApp.SEARCHTYPE_DIA);
 
   // 駅名入力パーツ#1初期化
   stationApp1 = new expGuiStation(document.getElementById("station1"));
@@ -217,7 +218,7 @@ function result(isSuccess){
 <!-- 日付入力パーツ -->
 <table class="sample">
   <tr>
-    <td class="sample_title">出発日</td>
+    <td class="sample_title">出発日時</td>
   </tr>
   <tr>
     <td>


### PR DESCRIPTION
## Summary
- enable time selection for route search by using dia search type
- adjust heading to show '出発日時'
- clarify README that the route sample allows time specification

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f981b331c832a9639dd9f44bb6cac